### PR TITLE
Support anonymous authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ seen the Bash version I had before it.
 
 Many queries involve complex JQL statements, which requires authentication to execute. 
 The tool expects the property file with your user/login for OpenJDK bug database
-(comes with a glorious OpenJDK Author role, after some contributions):
+(comes with a glorious OpenJDK Author role, after some contributions).
+By default, application uses a file "auth.props" with user/pass as authenticated method.
+An empty auth.props file will switch to use anonymous authentication.
 
        $ cat auth.props
        user=duke

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ seen the Bash version I had before it.
 ## What Do I Need... Wait, Do I Really Need To Run It?
 
 Many queries involve complex JQL statements, which requires authentication to execute. 
-The tool expects the property file with your user/login for OpenJDK bug database
+The tool expects the property file with your user/pass login for OpenJDK bug database
 (comes with a glorious OpenJDK Author role, after some contributions).
-By default, application uses a file "auth.props" with user/pass as authenticated method.
-An empty auth.props file will switch to use anonymous authentication.
+By default, application uses a file "auth.props" with user/pass to authenticate.
+Without "auth.props" or an empty "auth.props" both fall back to anonymous authentication.
 
        $ cat auth.props
        user=duke

--- a/src/main/java/org/openjdk/backports/Main.java
+++ b/src/main/java/org/openjdk/backports/Main.java
@@ -46,21 +46,7 @@ public class Main {
 
         try {
             if (options.parse()) {
-                Properties p = new Properties();
-                try (FileInputStream fis = new FileInputStream(options.getAuthProps())){
-                    p.load(fis);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-
-                String user = p.getProperty("user");
-                String pass = p.getProperty("pass");
-
-                if (user == null || pass == null) {
-                    throw new IllegalStateException("user/pass keys are missing in auth file: " + options.getAuthProps());
-                }
-
-                try (Clients cli = Connect.getClients(JIRA_URL, user, pass)) {
+                try (Clients cli = Connect.getClients(JIRA_URL)) {
                     PrintStream debugLog = System.out;
                     String logPrefix = options.getLogPrefix();
 

--- a/src/main/java/org/openjdk/backports/Main.java
+++ b/src/main/java/org/openjdk/backports/Main.java
@@ -46,7 +46,17 @@ public class Main {
 
         try {
             if (options.parse()) {
-                try (Clients cli = Connect.getClients(JIRA_URL)) {
+                Properties p = new Properties();
+                try (FileInputStream fis = new FileInputStream(options.getAuthProps())){
+                    p.load(fis);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                String user = p.getProperty("user");
+                String pass = p.getProperty("pass");
+
+                try (Clients cli = Connect.getClients(JIRA_URL, user, pass)) {
                     PrintStream debugLog = System.out;
                     String logPrefix = options.getLogPrefix();
 

--- a/src/main/java/org/openjdk/backports/Main.java
+++ b/src/main/java/org/openjdk/backports/Main.java
@@ -32,6 +32,7 @@ import org.openjdk.backports.report.html.*;
 import org.openjdk.backports.report.model.*;
 import org.openjdk.backports.report.text.*;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -46,15 +47,18 @@ public class Main {
 
         try {
             if (options.parse()) {
-                Properties p = new Properties();
-                try (FileInputStream fis = new FileInputStream(options.getAuthProps())){
-                    p.load(fis);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+                String user = null;
+                String pass = null;
+                if (new File(options.getAuthProps()).exists()) {
+                    Properties p = new Properties();
+                    try (FileInputStream fis = new FileInputStream(options.getAuthProps())){
+                        p.load(fis);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    user = p.getProperty("user");
+                    pass = p.getProperty("pass");
                 }
-
-                String user = p.getProperty("user");
-                String pass = p.getProperty("pass");
 
                 try (Clients cli = Connect.getClients(JIRA_URL, user, pass)) {
                     PrintStream debugLog = System.out;

--- a/src/main/java/org/openjdk/backports/jira/Connect.java
+++ b/src/main/java/org/openjdk/backports/jira/Connect.java
@@ -29,7 +29,8 @@ import com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.httpclient.api.factory.HttpClientOptions;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
-import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
+// import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
+import com.atlassian.jira.rest.client.auth.AnonymousAuthenticationHandler;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.AtlassianHttpClientDecorator;
 import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
@@ -48,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Connect {
 
-    public static Clients getClients(String jiraURL, String user, String pass) throws URISyntaxException {
+    public static Clients getClients(String jiraURL) throws URISyntaxException {
         final URI uri = new URI(jiraURL);
 
         DefaultHttpClientFactory factory = new DefaultHttpClientFactory(
@@ -79,7 +80,8 @@ public class Connect {
 
         DisposableHttpClient dispClient = new AtlassianHttpClientDecorator(
                 client,
-                new BasicHttpAuthenticationHandler(user, pass)) {
+                // change to use anoymous auth
+                new AnonymousAuthenticationHandler()) {
                     @Override public void destroy() throws Exception { factory.dispose(client); }
         };
 

--- a/src/main/java/org/openjdk/backports/jira/Connect.java
+++ b/src/main/java/org/openjdk/backports/jira/Connect.java
@@ -79,9 +79,11 @@ public class Connect {
 
         HttpClient client = factory.create(opts);
 
-        AuthenticationHandler auth = new AnonymousAuthenticationHandler();
+        AuthenticationHandler auth;
         if (user != null && pass != null) {
             auth = new BasicHttpAuthenticationHandler(user, pass);
+        } else {
+            auth = new AnonymousAuthenticationHandler();
         }
         DisposableHttpClient dispClient = new AtlassianHttpClientDecorator(client, auth) {
             @Override public void destroy() throws Exception { factory.dispose(client); }

--- a/src/main/java/org/openjdk/backports/jira/Connect.java
+++ b/src/main/java/org/openjdk/backports/jira/Connect.java
@@ -29,7 +29,7 @@ import com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.httpclient.api.factory.HttpClientOptions;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
-// import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
+import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
 import com.atlassian.jira.rest.client.auth.AnonymousAuthenticationHandler;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClient;
 import com.atlassian.jira.rest.client.internal.async.AtlassianHttpClientDecorator;
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Connect {
 
-    public static Clients getClients(String jiraURL) throws URISyntaxException {
+    public static Clients getClients(String jiraURL, String user, String pass) throws URISyntaxException {
         final URI uri = new URI(jiraURL);
 
         DefaultHttpClientFactory factory = new DefaultHttpClientFactory(
@@ -78,17 +78,29 @@ public class Connect {
 
         HttpClient client = factory.create(opts);
 
-        DisposableHttpClient dispClient = new AtlassianHttpClientDecorator(
-                client,
-                // change to use anoymous auth
-                new AnonymousAuthenticationHandler()) {
-                    @Override public void destroy() throws Exception { factory.dispose(client); }
-        };
+        if (user != null && pass != null) {
+            DisposableHttpClient dispClient = new AtlassianHttpClientDecorator(
+                    client,
+                    new BasicHttpAuthenticationHandler(user, pass)) {
+                        @Override public void destroy() throws Exception { factory.dispose(client); }
+            };
 
-        return new Clients(
-                new AsynchronousJiraRestClient(uri, dispClient),
-                new RawRestClient(uri, dispClient)
-        );
+            return new Clients(
+                    new AsynchronousJiraRestClient(uri, dispClient),
+                    new RawRestClient(uri, dispClient)
+            );
+        } else { // change to use anoymous auth
+            DisposableHttpClient dispClient = new AtlassianHttpClientDecorator(
+                    client,
+                    new AnonymousAuthenticationHandler()) {
+                        @Override public void destroy() throws Exception { factory.dispose(client); }
+            };
+
+            return new Clients(
+                    new AsynchronousJiraRestClient(uri, dispClient),
+                    new RawRestClient(uri, dispClient)
+            );
+        }
     }
 
     private static class MyEventPublisher implements EventPublisher {


### PR DESCRIPTION
In the current implementation, it requires a config file (by default auth.props) to have user and pass set. Otherwise, application return 401. Thinking it might not really need to have a user, if we can directly query from website as non-logined user, it should not be difference to query these information as anonymous with Jrjc client. 
This PR is intend to make both ways work: 
- when auth.props file has user/pass, use BasicHttpAuthenticationHandler
- when auth.props is empty, use AnonymousAuthenticationHandler
- when no auth.props file exists, use AnonymousAuthenticationHandler