### PR TITLE
Use environment variables for credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+.idea/
+auth.props
+*.iml

--- a/src/main/java/org/openjdk/backports/Main.java
+++ b/src/main/java/org/openjdk/backports/Main.java
@@ -58,6 +58,9 @@ public class Main {
                     }
                     user = p.getProperty("user");
                     pass = p.getProperty("pass");
+                } else {
+                    user = System.getenv().getOrDefault("OPENJDK_USER", null);
+                    pass = System.getenv().getOrDefault("OPENJDK_PASSWORD", null);
                 }
 
                 try (Clients cli = Connect.getClients(JIRA_URL, user, pass)) {


### PR DESCRIPTION
This PR allows for running the backports monitor without saving credentials on the disk, required when running in public environments.

If the given credential file does not exist, then the environment variables OPENJDK_USER and OPENJDK_PASSWORD are used to define the credentials to use.  If one or both of these variables do not exist, no error is given at that point, which is the current behaviour.

A .gitignore file is also added to avoid inadvertently checking in the default credentials file and to hide the target and (if present) intellij files from Git.
